### PR TITLE
[PlutoTV - golangtest] upgrades checkoutservice base image to golang 1.22

### DIFF
--- a/src/checkoutservice/Dockerfile
+++ b/src/checkoutservice/Dockerfile
@@ -34,7 +34,7 @@ RUN ./slcli config init --lang go --token ${SEALIGHTS_TOKEN}
 #Making the build session id 
 RUN ./slcli config create-bsid --app ${SERVICE_NAME} --branch ${BRANCH} --build ${BUILD_NAME}
 #Scanning the code
-RUN ./slcli scan --bsid buildSessionId.txt --path-to-scanner ./slgoagent --workspacepath ./ --scm none --packages-excluded "github.com/GoogleCloudPlatform/microservices-demo/src/checkoutservice/genproto"
+RUN ./slcli scan --bsid buildSessionId.txt --path-to-scanner ./slgoagent --workspacepath ./ --scm git --scmBaseUrl https://github.com/Sealights-btq/sam-btq --packages-excluded "github.com/GoogleCloudPlatform/microservices-demo/src/checkoutservice/genproto"
 
 RUN go build -gcflags="${SKAFFOLD_GO_GCFLAGS}" -o /checkoutservice .
 RUN go mod download
@@ -53,7 +53,7 @@ COPY --from=builder /checkoutservice /src/checkoutservice
 # Default behavior - a failure prints a stack trace for the current goroutine
 # See https://golang.org/pkg/runtime/
 ENV GOTRACEBACK=single
-ENV SEALIGHTS_LOG_LEVEL=info
+ENV SEALIGHTS_LOG_LEVEL=debug
 
 
 EXPOSE 5050


### PR DESCRIPTION
in addition to updating the golang base image to v1.22., this PR:
- updates the checkoutservice dockerfile to add "scm" flags to slcli command and set log level to debug